### PR TITLE
Make enterprise attributes optional

### DIFF
--- a/fastapi_slack.py
+++ b/fastapi_slack.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qsl
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pkg_resources import get_distribution
 from pydantic import BaseModel, BaseSettings, SecretStr, ValidationError
+from typing import Optional
 
 __all__ = ["SlashCommand", "router"]
 __version__ = get_distribution("fastapi-slack").version
@@ -83,8 +84,8 @@ class SlashCommand(BaseModel):
     token: str
     team_id: str
     team_domain: str
-    enterprise_id: str
-    enterprise_name: str
+    enterprise_id: Optional[str]
+    enterprise_name: Optional[str]
     channel_id: str
     channel_name: str
     user_id: str


### PR DESCRIPTION
Allow to receive commands from non-enterprise workspaces

## Description

At this moment, if a slash command coming from a non-enterprise workspace (or even an enterprise workspace which does not send these attributes), the slash command is immediately stopped from being processed because these two attributes are missing. 
How about they are optional so anyone even without enterprise can use this library?

<!-- don't remove -->
[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9
[Draft PR]: https://github.blog/2019-02-14-introducing-draft-pull-requests
